### PR TITLE
Fix decoding of DateTime

### DIFF
--- a/src/com/twistedmatrix/amp/AMPBox.java
+++ b/src/com/twistedmatrix/amp/AMPBox.java
@@ -387,25 +387,17 @@ public class AMPBox implements Map<byte[], byte[]> {
 	    } else if (t == Calendar.class ||
 		       t.getSuperclass() == Calendar.class) {
 		String s = asString(toDecode);
-		Date date = new Date();
 		SimpleDateFormat dtf =
-		    new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
+		    new SimpleDateFormat(s.length() == 32?
+					 "yyyy-MM-dd'T'HH:mm:ss.SSSX" :
+					 "yyyy-MM-dd'T'HH:mm:ss.SSS");
 		try {
-		    date = dtf.parse(s);
+		    dtf.parse(s.substring(0, 23) + s.substring(26));
 		} catch (ParseException pe) {
 		    throw new Error ("Unable to parse date '" + s + "'!");
 		}
 
-		Calendar cal = Calendar.getInstance();
-		cal.setTime(date);
-
-		if (s.length() == 32) {
-		    String tzid = "UTC" + s.substring(26, 32);
-		    TimeZone tz = TimeZone.getTimeZone(tzid);
-		    cal.setTimeZone(tz);
-		}
-
-		return cal;
+		return dtf.getCalendar();
 	    } else if (t.getSuperclass() == AmpItem.class) {
 		List<Object> result = new ArrayList<Object>();
 		Map<String,Class> params = new HashMap<String,Class>();

--- a/src/com/twistedmatrix/amp/AMPBox.java
+++ b/src/com/twistedmatrix/amp/AMPBox.java
@@ -517,27 +517,13 @@ public class AMPBox implements Map<byte[], byte[]> {
         } else if (t == BigDecimal.class) {
 	    value = asBytes(((BigDecimal) o).toString());
 	} else if (t == Calendar.class || t.getSuperclass() == Calendar.class) {
-	    String dir = "+";
 	    Calendar cal = (Calendar) o;
-	    TimeZone tz = cal.getTimeZone();
-	    long tzhours = TimeUnit.MILLISECONDS.toHours(tz.getRawOffset());
-	    long tzmins = TimeUnit.MILLISECONDS.toMinutes(tz.getRawOffset())
-		- TimeUnit.HOURS.toMinutes(tzhours);
-	    if (tzhours < 0) {
-		dir = "-";
-		tzhours = 0 - tzhours;
-	    }
-
-	    String str = String.format("%04d-%02d-%02dT%02d:%02d:%02d.%03d000" +
-				       "%s%02d:%02d", cal.get(cal.YEAR),
-				       cal.get(cal.MONTH),
-				       cal.get(cal.DAY_OF_MONTH),
-				       cal.get(cal.HOUR_OF_DAY),
-				       cal.get(cal.MINUTE), cal.get(cal.SECOND),
-				       cal.get(cal.MILLISECOND),
-				       dir, tzhours, tzmins);
-
-	    value = asBytes(str);
+	    int offs = cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET);
+	    SimpleDateFormat dtf = new SimpleDateFormat(offs == 0?
+							"yyyy-MM-dd'T'HH:mm:ss.SSS'000-00:00'" :
+							"yyyy-MM-dd'T'HH:mm:ss.SSS'000'XXX");
+	    dtf.setCalendar(cal);
+	    value = asBytes(dtf.format(cal.getTime()));
 	} else if (t.getSuperclass() == AmpItem.class) {
 	    Field[] fields = t.getFields();
 	    ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/src/com/twistedmatrix/amp/AMPBox.java
+++ b/src/com/twistedmatrix/amp/AMPBox.java
@@ -389,7 +389,7 @@ public class AMPBox implements Map<byte[], byte[]> {
 		String s = asString(toDecode);
 		SimpleDateFormat dtf =
 		    new SimpleDateFormat(s.length() == 32?
-					 "yyyy-MM-dd'T'HH:mm:ss.SSSX" :
+					 "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" :
 					 "yyyy-MM-dd'T'HH:mm:ss.SSS");
 		try {
 		    dtf.parse(s.substring(0, 23) + s.substring(26));


### PR DESCRIPTION
There were two issues:

* The use of "SSSSSS" in SimpleDateFormat to parse microseconds does not
  work.  "S" indicates milliseconds, so the added offset was 1000 times
  too large.  It is necessary to remove the last three digits and use
  "SSS" instead.

* The timezone handling was incorrect.  By having SimpleDateFormat
  parse the timestamp without the timezone, it would adjust the UTC
  time in the generated Date object based on the local timezone.
  So even though the resulting Calendar object would have the correct
  timezone, the actual time would be wrong.  By letting
  SimpleDateFormat parse the timezone and generate the Calendar object,
  this problem is avoided.