### PR TITLE
Fixes for _pendingCalls

### DIFF
--- a/src/com/twistedmatrix/internet/Reactor.java
+++ b/src/com/twistedmatrix/internet/Reactor.java
@@ -13,6 +13,7 @@ import java.nio.channels.SelectionKey;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.AbstractMap;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Iterator;
@@ -43,7 +44,11 @@ public class Reactor {
     public Reactor () throws IOException {
         _selector = Selector.open();
         _running = false;
-        _pendingCalls = new PriorityQueue<>();
+        _pendingCalls = new PriorityQueue<>(11, new Comparator<Map.Entry<Long,Runnable>>() {
+	    public int compare(Map.Entry<Long,Runnable> o1, Map.Entry<Long,Runnable> o2) {
+	      return o1.getKey().compareTo(o2.getKey());
+	    }
+	});
     }
 
     /* It appears that this interface is actually unnamed in

--- a/src/com/twistedmatrix/internet/Reactor.java
+++ b/src/com/twistedmatrix/internet/Reactor.java
@@ -12,7 +12,9 @@ import java.nio.channels.SocketChannel;
 import java.nio.channels.SelectionKey;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.TreeMap;
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Executor;
@@ -36,12 +38,12 @@ public class Reactor {
     private        TCPConnection          _connection;
     private        Selector               _selector;
     private        boolean                _running;
-    private        TreeMap<Long,Runnable> _pendingCalls;
+    private        PriorityQueue<Map.Entry<Long,Runnable>> _pendingCalls;
 
     public Reactor () throws IOException {
         _selector = Selector.open();
         _running = false;
-        _pendingCalls = new TreeMap<Long,Runnable>();
+        _pendingCalls = new PriorityQueue<>();
     }
 
     /* It appears that this interface is actually unnamed in
@@ -556,19 +558,16 @@ public class Reactor {
 	for (;;) {
 	    Runnable r;
 	    synchronized(_pendingCalls) {
-		if (0 == _pendingCalls.size()) {
+		Map.Entry<Long,Runnable> head = _pendingCalls.peek();
+		if (head == null) {
 		    break;
 		}
-		try {
-		    long then = _pendingCalls.firstKey();
-		    if (then < now) {
-			r = _pendingCalls.remove((Object) new Long(then));
-		    } else {
-			return then - now;
-		    }
-		} catch (NoSuchElementException nsee) {
-		    nsee.printStackTrace();
-		    throw new Error("Impossible; _pendingCalls.size was not zero");
+		long then = head.getKey();
+		if (then < now) {
+		    r = head.getValue();
+		    _pendingCalls.remove(head);
+		} else {
+		    return then - now;
 		}
 	    }
 	    r.run();
@@ -611,7 +610,7 @@ public class Reactor {
     public void callLater(double secondsLater, Runnable runme) {
         long millisLater = (long) (secondsLater * 1000.0);
         synchronized(_pendingCalls) {
-            _pendingCalls.put(System.currentTimeMillis() + millisLater, runme);
+            _pendingCalls.add(new AbstractMap.SimpleImmutableEntry<>(System.currentTimeMillis() + millisLater, runme));
             // This isn't actually an interestOps
             interestOpsChanged();
         }

--- a/src/com/twistedmatrix/internet/Reactor.java
+++ b/src/com/twistedmatrix/internet/Reactor.java
@@ -553,20 +553,26 @@ public class Reactor {
      * timeout.  Negative timeout means "no timeout".
      */
     private long runUntilCurrent(long now) {
-        while (0 != _pendingCalls.size()) {
-            try {
-                long then = _pendingCalls.firstKey();
-                if (then < now) {
-                    Runnable r = _pendingCalls.remove((Object) new Long(then));
-                    r.run();
-                } else {
-                    return then - now;
-                }
-            } catch (NoSuchElementException nsee) {
-                nsee.printStackTrace();
-                throw new Error("Impossible; _pendingCalls.size was not zero");
-            }
-        }
+	for (;;) {
+	    Runnable r;
+	    synchronized(_pendingCalls) {
+		if (0 == _pendingCalls.size()) {
+		    break;
+		}
+		try {
+		    long then = _pendingCalls.firstKey();
+		    if (then < now) {
+			r = _pendingCalls.remove((Object) new Long(then));
+		    } else {
+			return then - now;
+		    }
+		} catch (NoSuchElementException nsee) {
+		    nsee.printStackTrace();
+		    throw new Error("Impossible; _pendingCalls.size was not zero");
+		}
+	    }
+	    r.run();
+	}
         return -1;
     }
 


### PR DESCRIPTION
The use of a `TreeMap`  for `_pendingCalls` meant that if two pending calls where scheduled for the same millisecond, the second one would replace the first (since that is how `put()` works in a `Map`).  Changed it to a `PriorityQueue` instead.

Also, _all_ accesses to `_pendingCalls` need to be `synchronized` for calls to `callLater()` from other threads to not cause a race condition.