### PR TITLE
Catch all IO exceptions on TCP connect

### DIFF
--- a/src/com/twistedmatrix/internet/Reactor.java
+++ b/src/com/twistedmatrix/internet/Reactor.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.ConnectException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
@@ -502,7 +501,7 @@ public class Reactor {
 		this.channel.finishConnect();
 		super.startReading();
 		this.protocol.makeConnection(this);
-	    } catch (ConnectException e) {
+	    } catch (IOException e) {
 		connectionFailed(e);
 	    }
         }
@@ -542,7 +541,7 @@ public class Reactor {
 		super.startReading();
 		this.wrap(); // Initiate the handshake
 		while (this.step()) { continue; } // Complete the handshake
-	    } catch (ConnectException e) {
+	    } catch (IOException e) {
 		connectionFailed(e);
 	    }
 	}


### PR DESCRIPTION
`java.nio.channels.SocketChannel.finishConnect()` can throw `java.net.NoRouteToHostException`, which is a `SocketException` but not a `ConnectException`.  Thus the exception would fall through the over-specific catch and cause the reactor to stop.

Changed to catch IOException, which covers all exceptions thrown by `finishConnect()`, instead.